### PR TITLE
Changed getThread to fetch threads using title instead of id

### DIFF
--- a/src/controllers/threads.ts
+++ b/src/controllers/threads.ts
@@ -16,11 +16,10 @@ export const getAllThreads = async (req: Request, res: Response) => {
 
 // get thread details
 export const getThread = async (req: Request, res: Response) => {
-    const id = req.params.id;
-    if (!Types.ObjectId.isValid(id)) return res.status(404).json({ message: "Thread not found." });
+    const title = req.params.title;
 
     await Thread
-        .findOne({ _id: id })
+        .findOne({ title })
         .then(thread => res.status(200).json(thread))
         .catch(err => {
             console.log(err);

--- a/src/routes/threads.ts
+++ b/src/routes/threads.ts
@@ -8,6 +8,6 @@ const router = express.Router();
 router.get("/", getAllThreads);
 router.post("/create", isLoggedIn, createThread);
 
-router.get("/:id", getThread);
+router.get("/:title", getThread);
 
 export default router;


### PR DESCRIPTION
Since frontend does not have access to thread id and because thread titles are unique anyway, changed the getThread route to fetch and return threads using their title.